### PR TITLE
Update name to Kùzu Explorer and fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# KùzuExplorer
+# Kùzu Explorer
 
 Browser-based user interface for the [Kùzu](https://github.com/kuzudb/kuzu) graph database.
 
@@ -6,11 +6,11 @@ Browser-based user interface for the [Kùzu](https://github.com/kuzudb/kuzu) gra
 
 ## Get started
 
-KùzuExplorer is a web application that is launched from a deployed Docker image.
+Kùzu Explorer is a web application that is launched from a deployed Docker image.
 Please refer to the [Docker documentation](https://docs.docker.com/get-docker/) for details on how to install and use Docker.
 
-Below we show two different ways to launch KùzuExplorer. Each of these options make
-KùzuExplorer accessible on [http://localhost:8000](http://localhost:8000). If the launching is successful, you should see the logs similar to the following in your shell:
+Below we show two different ways to launch Kùzu Explorer. Each of these options make
+Kùzu Explorer accessible on [http://localhost:8000](http://localhost:8000). If the launching is successful, you should see the logs similar to the following in your shell:
 
 ```
 Access mode: READ_WRITE
@@ -35,7 +35,7 @@ The `--rm` flag tells docker that the container should automatically be removed 
 
 ### Option 2: Start with an empty database with example data
 
-You can also launch KùzuExplorer without specifying an existing database. KùzuExplorer comes with
+You can also launch Kùzu Explorer without specifying an existing database. Kùzu Explorer comes with
 bundled datasets that you can use to explore the basic functionalities of Kùzu.
 This is simply done by removing the `-v` flag in the example above. If no database path is specified
 with `-v`, the server will be started with an empty database.
@@ -46,13 +46,13 @@ docker run -p 8000:8000 --rm kuzudb/explorer:latest
 
 Click on the `Datasets` tab on the top right corner and then: (i) you can select one of the bundled dataset
 of your choice from the drow-down menu; (ii) load it into Kùzu by clicking the "Load Dataset" button; and (iii)
-finally use KùzuExplorer to explore it.
+finally use Kùzu Explorer to explore it.
 
 ### Additional launch configurations
 
 #### Access mode
 
-By default, KùzuExplorer is launched in read-write mode, which means that you can modify the database. If you want to launch KùzuExplorer in read-only mode, you can do so by setting the `MODE` environment variable to `READ_ONLY` as follows.
+By default, Kùzu Explorer is launched in read-write mode, which means that you can modify the database. If you want to launch Kùzu Explorer in read-only mode, you can do so by setting the `MODE` environment variable to `READ_ONLY` as follows.
 
 ```bash
 docker run -p 8000:8000 \
@@ -65,9 +65,9 @@ In read-only mode, you can still issue read queries and visualize the results, b
 
 #### Buffer pool size
 
-By default, KùzuExplorer is launched with a maximum buffer pool size of 80% of the available memory. If you want to launch KùzuExplorer with a different buffer pool size, you can do so by setting the `KUZU_BUFFER_POOL_SIZE` environment variable to the desired value in bytes as follows.
+By default, Kùzu Explorer is launched with a maximum buffer pool size of 80% of the available memory. If you want to launch Kùzu Explorer with a different buffer pool size, you can do so by setting the `KUZU_BUFFER_POOL_SIZE` environment variable to the desired value in bytes as follows.
 
-For example, to launch KùzuExplorer with a buffer pool size of 1GB, you can run the following command.
+For example, to launch Kùzu Explorer with a buffer pool size of 1GB, you can run the following command.
 
 ```bash
 docker run -p 8000:8000 \
@@ -100,7 +100,7 @@ After pulling the latest image, you can re-launch the container with the same co
 
 ### Launch with Podman
 
-If you are using [Podman](https://podman.io/) instead of Docker, you can launch KùzuExplorer by replacing `docker` with `podman` in the commands above. However, note that by default Podman maps the default user account to the `root` user in the container. This may cause permission issues when mounting local database files to the container. To avoid this, you can use the `--userns=keep-id` flag to keep the user ID of the current user inside the container, or enable `:U` option for each volume to change the owner and group of the source volume to the current user.
+If you are using [Podman](https://podman.io/) instead of Docker, you can launch Kùzu Explorer by replacing `docker` with `podman` in the commands above. However, note that by default Podman maps the default user account to the `root` user in the container. This may cause permission issues when mounting local database files to the container. To avoid this, you can use the `--userns=keep-id` flag to keep the user ID of the current user inside the container, or enable `:U` option for each volume to change the owner and group of the source volume to the current user.
 
 For example:
 
@@ -123,7 +123,7 @@ Please refer to the official Podman docs for [mounting external volumes](https:/
 
 ## Documentation
 
-For more information regarding launching and using KùzuExplorer, please refer to the [documentation](https://kuzudb.com/docusaurus/kuzuexplorer).
+For more information regarding launching and using Kùzu Explorer, please refer to the [documentation](https://kuzudb.com/docusaurus/kuzuexplorer).
 
 ## Development (with Kùzu compiled from source)
 
@@ -217,4 +217,4 @@ for both `amd64` and `arm64` platforms.
 
 ## Contributing
 
-We welcome contributions to KùzuExplorer. By contributing to KùzuExplorer, you agree that your contributions will be licensed under the [MIT License](LICENSE).
+We welcome contributions to Kùzu Explorer. By contributing to Kùzu Explorer, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Please refer to the official Podman docs for [mounting external volumes](https:/
 
 ## Documentation
 
-For more information regarding launching and using Kùzu Explorer, please refer to the [documentation](https://kuzudb.com/docusaurus/kuzuexplorer).
+For more information regarding launching and using Kùzu Explorer, please refer to the [documentation](https://docs.kuzudb.com).
 
 ## Development (with Kùzu compiled from source)
 
@@ -143,7 +143,7 @@ For more information regarding launching and using Kùzu Explorer, please refer 
 
 - [Node.js v20](https://nodejs.org/dist/latest-v20.x/)
 - [JDK 11+](https://jdk.java.net/11/)
-- [Toolchain for building Kùzu](https://kuzudb.com/docusaurus/development/building-kuzu)
+- [Toolchain for building Kùzu](https://docs.kuzudb.com/developer-guide/)
 - [Git](https://git-scm.com/)
 
 ### Environment setup

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ docker run -p 8000:8000 \
 
 #### Dev builds
 
-If you want to launch KùzuExplorer with the latest development build of Kùzu, you can do so by using the `dev` tag instead of `latest`.
+If you want to launch Kùzu Explorer with the latest development build of Kùzu, you can do so by using the `dev` tag instead of `latest`.
 
 ```bash
 docker run -p 8000:8000 \
@@ -88,9 +88,9 @@ docker run -p 8000:8000 \
 
 The `dev` tag is updated daily, approximately two hours after the latest dev build of Kùzu is released.
 
-### Updating KùzuExplorer
+### Updating Kùzu Explorer
 
-When a new version of KùzuExplorer is released after the initial launch, re-launching the container WILL NOT automatically update the local image to the latest version. To update the local image to the latest version, you can run the following command.
+When a new version of Kùzu Explorer is released after the initial launch, re-launching the container WILL NOT automatically update the local image to the latest version. To update the local image to the latest version, you can run the following command.
 
 ```bash
 docker pull kuzudb/explorer:latest

--- a/src/components/DatasetView/DatasetMainView.vue
+++ b/src/components/DatasetView/DatasetMainView.vue
@@ -11,7 +11,7 @@
     >
       <i class="fa-solid fa-info-circle" />
       You have already loaded a database. You can still review the schema of the bundled
-      datasets. If you want to load a different dataset, please restart your KùzuExplorer
+      datasets. If you want to load a different dataset, please restart your Kùzu Explorer
       Docker image with an empty database or drop all tables in the current database.
     </div>
 
@@ -31,7 +31,7 @@
       role="alert"
     >
       <i class="fa-solid fa-info-circle" />
-      You are running KùzuExplorer in development mode. You can load any dataset into the
+      You are running Kùzu Explorer in development mode. You can load any dataset into the
       database. However, please make sure there is no conflict with the existing schema.
     </div>
 
@@ -41,8 +41,8 @@
       role="alert"
     >
       <i class="fa-solid fa-info-circle" />
-      KùzuExplorer is running in read-only mode. You can still review the schema of the
-      bundled datasets. If you want to load a dataset, please restart your KùzuExplorer
+      Kùzu Explorer is running in read-only mode. You can still review the schema of the
+      bundled datasets. If you want to load a dataset, please restart your Kùzu Explorer
       Docker image in read-write mode with an empty database.
     </div>
 
@@ -52,9 +52,9 @@
       role="alert"
     >
       <i class="fa-solid fa-info-circle" />
-      KùzuExplorer is running in demo mode. You can still review the schema of the bundled
+      Kùzu Explorer is running in demo mode. You can still review the schema of the bundled
       datasets. Loading a dataset is not possible in this demo. However, you can load a
-      bundled dataset or use your own dataset if you run KùzuExplorer locally. Please
+      bundled dataset or use your own dataset if you run Kùzu Explorer locally. Please
       refer to
       <a
         target="_blank"

--- a/src/components/DatasetView/DatasetMainView.vue
+++ b/src/components/DatasetView/DatasetMainView.vue
@@ -58,7 +58,7 @@
       refer to
       <a
         target="_blank"
-        href="https://kuzudb.com/docusaurus/kuzuexplorer/"
+        href="https://docs.kuzudb.com"
       >
         the documentation </a>for more information.
     </div>

--- a/src/components/MainLayout.vue
+++ b/src/components/MainLayout.vue
@@ -97,7 +97,7 @@
             <li class="nav-item">
               <a
                 class="nav-link"
-                href="https://kuzudb.com/docusaurus/"
+                href="https://docs.kuzudb.com"
                 target="_blank"
               >
                 <i class="fa-solid fa-book" />

--- a/src/components/MainLayout.vue
+++ b/src/components/MainLayout.vue
@@ -157,7 +157,7 @@
             class="modal-header"
           >
             <h5 class="modal-title">
-              Welcome to KùzuExplorer!
+              Welcome to Kùzu Explorer!
             </h5>
           </div>
           <div class="modal-body">
@@ -166,7 +166,7 @@
               <a href="https://ldbcouncil.org/benchmarks/snb/">
                 LDBC Social Network Benchmark
               </a>
-              scale factor 0.1 dataset. Please run KùzuExplorer locally to load a
+              scale factor 0.1 dataset. Please run Kùzu Explorer locally to load a
               different dataset (see the
               <a href="https://kuzudb.com/docusaurus/kuzuexplorer/"> documentation here</a>).
               <br>
@@ -175,9 +175,9 @@
               interactive Cypher queries in the Shell tab.
             </p>
             <p v-if="modeStore.isReadOnly">
-              KùzuExplorer is running in read-only mode. In this mode, you cannot load a
+              Kùzu Explorer is running in read-only mode. In this mode, you cannot load a
               dataset, modify the schema, or execute write queries. If you want to make
-              changes to the database, please restart your KùzuExplorer Docker image in
+              changes to the database, please restart your Kùzu Explorer Docker image in
               read-write mode.
             </p>
           </div>

--- a/src/store/SettingsStore.js
+++ b/src/store/SettingsStore.js
@@ -221,7 +221,7 @@ export const useSettingsStore = defineStore("settings", {
       if (storedSettingsCopy.colors) {
         this.colors = storedSettingsCopy.colors;
       }
-      // The schema may be changed outside of KùzuExplorer, so we reset the
+      // The schema may be changed outside of Kùzu Explorer, so we reset the
       // graphViz settings and merge the stored settings with current schema.
       this.graphViz.nodes = {};
       this.graphViz.rels = {};

--- a/vue.config.js
+++ b/vue.config.js
@@ -11,7 +11,7 @@ module.exports = defineConfig({
   pages: {
     index: {
       entry: "src/main.js",
-      title: "KùzuExplorer",
+      title: "Kùzu Explorer",
     },
   },
   css: {


### PR DESCRIPTION
## Naming to "Kùzu Explorer"

When referring to our visualization tool, it makes sense to separate the term "Kùzu" from the tool's functionality ("Explorer"). This makes it less verbose, easier to read, and also to refer to multiple times in the same document (we could just say "Explorer" in capitalized form to refer to it as a proper noun). This is in line with other visualization tools in the market: I'm listing just two examples below, but there could be many more:

- Neo4j Desktop: https://neo4j.com/docs/desktop-manual/current/
- TypeDB Studio: https://typedb.com/docs/manual/studio

In this PR, I'm suggesting that we replace all instances of "KùzuExplorer" to "Kùzu Explorer" (with a space) to make it easier to reference in passing in our docs, tutorials and examples. I've already made this change in our docs, for example, here:
https://docs.kuzudb.com/visualization/

**NOTE:** We will still call it "Kùzu Explorer" in the first mention of any article that we write, to make it clear that we are referring to a Kùzu tool. However, for subsequent mentions, we can use the shorthand "Use our Explorer to..." or similar, to avoid being repetitive with the term "Kùzu" everywhere.

## Additional fixes

Broken URLs exist in other parts of the Kùzu Explorer code base. This PR fixes this.