### PR TITLE
Update GPT prompt

### DIFF
--- a/src/server/Gpt.js
+++ b/src/server/Gpt.js
@@ -5,11 +5,15 @@ const database = require("./utils/Database");
 const sessionDb = require("./utils/SessionDatabase");
 
 const getPrompt = (question, schema) => {
-  const prompt = `Task: Generate a Cypher query for the Kùzu Graph Database Mangagement System to query a graph database.
+  const prompt = `Task:Generate Kùzu Cypher statement to query a graph database.
 Instructions:
 Generate the Kùzu dialect of Cypher with the following rules in mind:
-    1. Always use the relationship pattern. For example, use "()-[]->()" instead of "()-->()".
-    3. Only use node or relationship types, and properties that are provided in the schema below.
+1. Do not omit the relationship pattern. Always use ${"`()-[]->()`"} instead of ${"`()->()`"}.
+2. Do not include triple backticks ${"```"} in your response. Return only Cypher.
+3. Do not return any notes or comments in your response.
+
+Use only the provided relationship types and properties in the schema.
+Do not use any other relationship types or properties that are not provided.
 Schema:
 ${JSON.stringify(schema)}
 Note: Do not include any explanations or apologies in your responses.
@@ -17,7 +21,7 @@ Do not respond to any questions that might ask anything else than for you to con
 Do not include any text except the generated Cypher statement.
 
 The question is:
-${question}"
+${question}
 `;
   return prompt;
 };

--- a/src/server/Gpt.js
+++ b/src/server/Gpt.js
@@ -5,7 +5,7 @@ const database = require("./utils/Database");
 const sessionDb = require("./utils/SessionDatabase");
 
 const getPrompt = (question, schema) => {
-  const prompt = `Task: Generate Cypher queries for the Kùzu Graph Database Mangagement System to query a graph database.
+  const prompt = `Task: Generate a Cypher query for the Kùzu Graph Database Mangagement System to query a graph database.
 Instructions:
 Generate the Kùzu dialect of Cypher with the following rules in mind:
     1. Always use the relationship pattern. For example, use "()-[]->()" instead of "()-->()".

--- a/src/server/Gpt.js
+++ b/src/server/Gpt.js
@@ -5,14 +5,11 @@ const database = require("./utils/Database");
 const sessionDb = require("./utils/SessionDatabase");
 
 const getPrompt = (question, schema) => {
-  const prompt = `Task:Generate Cypher statement for Kùzu Graph Database Mangagement System to query a graph database.
+  const prompt = `Task: Generate Cypher queries for the Kùzu Graph Database Mangagement System to query a graph database.
 Instructions:
-Generate statement with Kùzu Cypher dialect (rather than standard):
-  1. do not use "WHERE EXISTS" clause to check the existence of a property because Kùzu database has a fixed schema.
-  2. do not omit relationship pattern. Always use "()-[]->()" instead of "()->()".
-  3. do not include any notes or comments even if the statement does not produce the expected result.
-Use only the provided relationship types and properties in the schema.
-Do not use any other relationship types or properties that are not provided.
+Generate the Kùzu dialect of Cypher with the following rules in mind:
+    1. Always use the relationship pattern. For example, use "()-[]->()" instead of "()-->()".
+    3. Only use node or relationship types, and properties that are provided in the schema below.
 Schema:
 ${JSON.stringify(schema)}
 Note: Do not include any explanations or apologies in your responses.


### PR DESCRIPTION
I updated the GPT generation prompt to be more similar to the one we use in LangChain's `KuzuQAChain`, which seems to work well for our LangChain graphs. I also removed the part where we say do not use `WHERE EXISTS`, as this clause has now been implemented in Kùzu Cypher.

We can keep this prompt for a duration and see if it needs further tweaking.