### PR TITLE
Changed how explorer produces random colours for nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "antlr4ng": "1.0.7",
         "axios": "^1.4.0",
         "bootstrap": "^5.3.1",
+        "chroma-js": "^3.0.0",
         "core-js": "^3.8.3",
         "cors": "^2.8.5",
         "dropzone": "^6.0.0-beta.2",
@@ -5319,6 +5320,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/chroma-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-3.0.0.tgz",
+      "integrity": "sha512-ZFn4qxtZTvRJ7XatOLgaHGJYN10LoS6T0EMsu7IVayFG5+b6Yw8wCGQL5qLgo4B+wrRZ9niCrozOQ4a584bvaA==",
+      "license": "(BSD-3-Clause AND Apache-2.0)"
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "pinia": "^2.0.23",
         "pino": "^8.16.1",
         "pino-pretty": "^10.2.3",
-        "randomcolor": "^0.6.2",
         "sqlite": "^5.1.1",
         "sqlite3": "^5.1.7",
         "uuid": "^9.0.1",
@@ -12761,12 +12760,6 @@
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
-    },
-    "node_modules/randomcolor": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/randomcolor/-/randomcolor-0.6.2.tgz",
-      "integrity": "sha512-Mn6TbyYpFgwFuQ8KJKqf3bqqY9O1y37/0jgSK/61PUxV4QfIMv0+K2ioq8DfOjkBslcjwSzRfIDEXfzA9aCx7A==",
-      "license": "CC0"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "antlr4ng": "1.0.7",
     "axios": "^1.4.0",
     "bootstrap": "^5.3.1",
+    "chroma-js": "^3.0.0",
     "core-js": "^3.8.3",
     "cors": "^2.8.5",
     "dropzone": "^6.0.0-beta.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "pinia": "^2.0.23",
     "pino": "^8.16.1",
     "pino-pretty": "^10.2.3",
-    "randomcolor": "^0.6.2",
     "sqlite": "^5.1.1",
     "sqlite3": "^5.1.7",
     "uuid": "^9.0.1",

--- a/src/store/SettingsStore.js
+++ b/src/store/SettingsStore.js
@@ -24,8 +24,8 @@ const COLOR_PALETTE = [
 ];
 
 function randomChromaColor(){
-  const randomSaturation = Math.random() * 0.2 + 0.6; 
-  const randomLightness = Math.random() * 0.2 + 0.6; 
+  const randomSaturation = Math.random() * 0.2 + 0.6;  //Sets saturation to a random value between 0.6 and 0.8
+  const randomLightness = Math.random() * 0.2 + 0.6;   //Sets lightness to a random value between 0.6 and 0.8
   return chroma.random().set('hsl.s', randomSaturation).set('hsl.l', randomLightness).hex();
 }
 

--- a/src/store/SettingsStore.js
+++ b/src/store/SettingsStore.js
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import randomcolor from "randomcolor";
+import chroma, { random } from 'chroma-js';
 import Axios from "axios";
 import {
   SHOW_REL_LABELS_OPTIONS,
@@ -22,6 +22,12 @@ const COLOR_PALETTE = [
   "#59a14f", // green
   "#4e79a7", // blue
 ];
+
+function randomChromaColor(){
+  const randomSaturation = Math.random() * 0.2 + 0.6; 
+  const randomLightness = Math.random() * 0.2 + 0.6; 
+  return chroma.random().set('hsl.s', randomSaturation).set('hsl.l', randomLightness).hex();
+}
 
 const NULL_COLOR = "#d9d9d9";
 const DEFAULT_NUMBER_OF_NODES_TO_EXPAND = 100;
@@ -150,7 +156,7 @@ export const useSettingsStore = defineStore("settings", {
       const g6Settings = JSON.parse(JSON.stringify(nodeDefault));
       let color = this.colors.pop();
       if (!color) {
-        color = randomcolor({ luminosity: "dark", hue: "random" });
+        color = randomChromaColor();
       }
       g6Settings.style.fill = color;
       g6Settings.style.stroke = G6Utils.shadeColor(color);
@@ -311,7 +317,7 @@ export const useSettingsStore = defineStore("settings", {
       const g6Settings = JSON.parse(JSON.stringify(nodeDefault));
       let color = this.colors.pop();
       if (!color) {
-        color = randomcolor({ luminosity: "dark", hue: "random" });
+        color = randomChromaColor();
       }
       g6Settings.style.fill = color;
       const nodeSettings = {


### PR DESCRIPTION
I discussed this with @prrao87  and it seems like it works fine

I used the chroma-js module to generate random pastel colours that look more visually appealing.


Here are a couple examples:
![image](https://github.com/user-attachments/assets/b71ddedd-621f-4120-8b1d-ac9bb75da2f8)

![image](https://github.com/user-attachments/assets/686d6ab5-e5ce-44c5-b174-b3ff61d40aa5)
