### PR TITLE
Added dynamic force-directed layouts to Schema View

### DIFF
--- a/src/components/SchemaView/SchemaViewMain.vue
+++ b/src/components/SchemaView/SchemaViewMain.vue
@@ -242,18 +242,21 @@ export default {
       return relTable.group ? relTable.group : relTableName;
     },
     getLayoutConfig(edges) {
-      const nodeSpacing = edges.length * 5;
       const config = {
-        type: 'comboForce',
+        type: 'force',
         preventOverlap: true,
         preventNodeOverlap: true,
         preventComboOverlap: true,
-        linkDistance: 250,
-        nodeStrength: 100,
+        linkDistance: 30,
+        nodeStrength: 1,
         nodeSize: 100,
-        nodeSpacing,
         comboSpacing: 10,
         comboCollideStrength: 0.2,
+        edgeStrength: 0.1,
+        nodeSpacing: 80,
+        alpha: 0.5,
+        alphaDecay: 0.05,
+        alphaMin: 0.05,
       };
       return config;
     },
@@ -441,6 +444,10 @@ export default {
         this.clickedIsNode = false;
         this.clickedLabel = edgeItem._cfg.model._label;
       });
+
+      this.g6graph.on('node:drag', (e) => {
+          this.layoutGraph()
+      })
 
       this.g6graph.on('canvas:click', () => {
         if (this.clickedIsNewTable) {

--- a/src/components/SchemaView/SchemaViewMain.vue
+++ b/src/components/SchemaView/SchemaViewMain.vue
@@ -241,22 +241,26 @@ export default {
       }
       return relTable.group ? relTable.group : relTableName;
     },
+    
+    refreshDragedNodePosition(e) {
+      const model = e.item.get('model');
+      model.fx = e.x;
+      model.fy = e.y;
+    },
+
     getLayoutConfig(edges) {
+      const nodeSpacing = edges.length * 5;
       const config = {
-        type: 'force',
+        type: 'comboForce',
         preventOverlap: true,
         preventNodeOverlap: true,
         preventComboOverlap: true,
-        linkDistance: 30,
-        nodeStrength: 0.1,
+        linkDistance: 250,
+        nodeStrength: 100,
         nodeSize: 100,
         comboSpacing: 10,
         comboCollideStrength: 0.2,
-        edgeStrength: 0.1,
-        nodeSpacing: 80,
-        alpha: 0.5,
-        alphaDecay: 0.05,
-        alphaMin: 0.05,
+        nodeSpacing,
       };
       return config;
     },
@@ -446,7 +450,15 @@ export default {
       });
 
       this.g6graph.on('node:drag', (e) => {
-          this.layoutGraph()
+          this.refreshDragedNodePosition(e)
+      })
+      this.g6graph.on('node:dragstart', (e) => {
+          this.g6graph.layout()
+          this.refreshDragedNodePosition(e);
+      })
+      this.g6graph.on('node:dragend', (e) => {
+          e.item.get('model').fx = null;
+          e.item.get('model').fy = null;
       })
 
       this.g6graph.on('canvas:click', () => {

--- a/src/components/SchemaView/SchemaViewMain.vue
+++ b/src/components/SchemaView/SchemaViewMain.vue
@@ -248,7 +248,7 @@ export default {
         preventNodeOverlap: true,
         preventComboOverlap: true,
         linkDistance: 30,
-        nodeStrength: 1,
+        nodeStrength: 0.1,
         nodeSize: 100,
         comboSpacing: 10,
         comboCollideStrength: 0.2,


### PR DESCRIPTION
Addresses #173 

In this new change, the Schema view has the same dynamic force-directed layouts. You now can't put nodes ontop of each other, and nodes that come too close together get repelled

<img width="534" alt="image" src="https://github.com/user-attachments/assets/600c3c8d-6a7a-4454-bfe6-6fd599724dbb">
