### PR TITLE
Updates the OpenAI GPT model versions

### DIFF
--- a/src/utils/Constants.js
+++ b/src/utils/Constants.js
@@ -92,7 +92,7 @@ export const MODES = {
   WASM: "WASM",
 };
 
-export const GPT_MODELS = ["gpt-4o", "gpt-4o-mini", "gpt-4"];
+export const GPT_MODELS = ["gpt-4.1", "gpt-4o", "gpt-4o-mini"];
 export const LLM_PROVIDERS = {
   OPENAI: {text: "OpenAI", key: "OPENAI"},
   OTHERS: {text: "Other OpenAI-compatible API", key: "OTHERS"},


### PR DESCRIPTION
I removed OpenAI `gpt-4` because it's being deprecated soon (if not already), and it anyway generates rather poor Cypher. Their latest model, `gpt-4.1` is really good at generating Cypher, and I'd like to publicize this for people to use.