### PR TITLE
Fix issue with API key label for Gemini models

### DIFF
--- a/src/components/SettingsView/SettingsMainView.vue
+++ b/src/components/SettingsView/SettingsMainView.vue
@@ -312,14 +312,14 @@
             </div>
             <div class="settings-row">
               <span>
-
-                {{ isOpenAIApi ? 'OpenAI' : 'API' }} key
+                <span v-if="currentSettings.gpt.llmProvider === llmProviderOptions.OPENAI.key">OpenAI key</span>
+                <span v-else>API key</span>
               </span>
               <input
                 v-model="currentSettings.gpt.apiToken"
                 :type="showPassword ? 'text' : 'password'"
                 class="settings-input form-control"
-                :title="isOpenAIApi ? 'Enter the OpenAI API key' : 'Enter API key'"
+                :title="currentSettings.gpt.llmProvider === llmProviderOptions.OPENAI.key ? 'Enter the OpenAI API key' : 'Enter API key'"
               >
               <button
                 type="button"


### PR DESCRIPTION
Fixes issue with the text label when using Gemini models - rather than showing "OpenAI key" by default, when the provider is not OpenAI, it should show just "API key".
<img width="968" height="213" alt="image" src="https://github.com/user-attachments/assets/49586f88-41de-4b5d-8bb0-079c967a6ba0" />
